### PR TITLE
feat: add interakt api toolkit

### DIFF
--- a/real-estate-app/README.md
+++ b/real-estate-app/README.md
@@ -1,36 +1,36 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Interakt API Toolkit
+
+A tiny Next.js dashboard for validating [Interakt](https://www.interakt.ai/) REST API keys and sending plain WhatsApp session messages without a template. The UI proxies your API requests through Next.js route handlers so you never expose your key in the browser console.
+
+## Features
+
+- **API key checker** – Calls Interakt's template listing endpoint with your key and surfaces the HTTP status and payload so you can confirm the key is live.
+- **Plain message sender** – Submit a WhatsApp number, country code, and message body to fire a `type: "Plain"` request to Interakt's `/v1/public/message/` endpoint.
+- **Detailed responses** – Inspect the raw JSON (or text) returned by Interakt for both verification and message sends.
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) to use the toolkit. All requests are executed server-side through Next.js route handlers located in `src/app/api/interakt`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Usage Notes
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- Use your Interakt REST API key (the same string you pass as the `Authorization: Basic <key>` header).
+- Regular/plain messages only reach customers who are within a valid 24-hour service window with your WhatsApp Business Account.
+- The app does not persist any credentials or responses. Everything stays in memory per request.
 
-## Learn More
+## Scripts
 
-To learn more about Next.js, take a look at the following resources:
+| Command      | Description          |
+| ------------ | -------------------- |
+| `npm run dev`   | Start the local development server with Turbopack. |
+| `npm run lint`  | Run ESLint. |
+| `npm run build` | Build the production bundle. |
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Deployment
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Deploy this app to any platform that supports Next.js 15+ (Vercel, Netlify, Docker, etc.). Ensure outbound HTTPS requests to `https://api.interakt.ai` are allowed from your hosting environment.

--- a/real-estate-app/src/app/api/interakt/send/route.ts
+++ b/real-estate-app/src/app/api/interakt/send/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+
+type SendRequestBody = {
+  apiKey?: string;
+  countryCode?: string;
+  phoneNumber?: string;
+  message?: string;
+};
+
+const INTERAKT_MESSAGE_ENDPOINT = "https://api.interakt.ai/v1/public/message/";
+
+export async function POST(request: Request) {
+  let body: SendRequestBody;
+
+  try {
+    body = (await request.json()) as SendRequestBody;
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 400,
+        message: "Request body must be valid JSON.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const apiKey = body.apiKey?.trim();
+  const countryCode = body.countryCode?.trim() || "+91";
+  const phoneNumber = body.phoneNumber?.trim();
+  const message = body.message?.trim();
+
+  if (!apiKey || !phoneNumber || !message) {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 400,
+        message:
+          "API key, phone number, and message text are required to send a message.",
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const interaktResponse = await fetch(INTERAKT_MESSAGE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        countryCode,
+        phoneNumber,
+        type: "Plain",
+        message: {
+          text: message,
+        },
+      }),
+    });
+
+    const rawBody = await interaktResponse.text();
+    let parsedBody: unknown = null;
+    if (rawBody) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        parsedBody = rawBody;
+      }
+    }
+
+    if (!interaktResponse.ok) {
+      const errorMessage =
+        typeof parsedBody === "object" && parsedBody !== null && "message" in parsedBody
+          ? String((parsedBody as { message: unknown }).message)
+          : "Interakt rejected the message payload.";
+
+      return NextResponse.json(
+        {
+          ok: false,
+          status: interaktResponse.status,
+          message: errorMessage,
+          details: parsedBody,
+        },
+        { status: interaktResponse.status }
+      );
+    }
+
+    let messageText = "Message accepted by Interakt.";
+    if (typeof parsedBody === "object" && parsedBody !== null && "message" in parsedBody) {
+      messageText = String((parsedBody as { message: unknown }).message);
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        status: interaktResponse.status,
+        message: messageText,
+        details: parsedBody,
+      },
+      { status: interaktResponse.status }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 500,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unexpected error while contacting Interakt.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/real-estate-app/src/app/api/interakt/verify/route.ts
+++ b/real-estate-app/src/app/api/interakt/verify/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+
+type VerifyRequestBody = {
+  apiKey?: string;
+};
+
+const INTERAKT_TEMPLATES_ENDPOINT =
+  "https://api.interakt.ai/v1/public/templates/?page=1&limit=1";
+
+export async function POST(request: Request) {
+  let body: VerifyRequestBody;
+
+  try {
+    body = (await request.json()) as VerifyRequestBody;
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 400,
+        message: "Request body must be valid JSON.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const apiKey = body.apiKey?.trim();
+
+  if (!apiKey) {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 400,
+        message: "An Interakt API key is required for verification.",
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const interaktResponse = await fetch(INTERAKT_TEMPLATES_ENDPOINT, {
+      method: "GET",
+      headers: {
+        Authorization: `Basic ${apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    });
+
+    const rawBody = await interaktResponse.text();
+    let parsedBody: unknown = null;
+    if (rawBody) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        parsedBody = rawBody;
+      }
+    }
+
+    if (!interaktResponse.ok) {
+      const errorMessage =
+        typeof parsedBody === "object" && parsedBody !== null && "message" in parsedBody
+          ? String((parsedBody as { message: unknown }).message)
+          : "Interakt rejected the API key.";
+
+      return NextResponse.json(
+        {
+          ok: false,
+          status: interaktResponse.status,
+          message: errorMessage,
+          details: parsedBody,
+        },
+        { status: interaktResponse.status }
+      );
+    }
+
+    let message = "Interakt accepted the request.";
+    if (typeof parsedBody === "object" && parsedBody !== null) {
+      if ("message" in parsedBody) {
+        message = String((parsedBody as { message: unknown }).message);
+      } else if ("data" in parsedBody) {
+        message = "API key verified successfully.";
+      }
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        status: interaktResponse.status,
+        message,
+        details: parsedBody,
+      },
+      { status: interaktResponse.status }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        status: 500,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unexpected error while contacting Interakt.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/real-estate-app/src/app/layout.tsx
+++ b/real-estate-app/src/app/layout.tsx
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Real Estate Finder",
-  description: "Interactive map and list to find your next home.",
+  title: "Interakt API Toolkit",
+  description: "Validate Interakt REST API keys and send plain WhatsApp messages.",
 };
 
 export default function RootLayout({
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-zinc-50 dark:bg-zinc-950`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-950`}>
         {children}
       </body>
     </html>

--- a/real-estate-app/src/app/page.tsx
+++ b/real-estate-app/src/app/page.tsx
@@ -1,118 +1,369 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { properties as seedProperties } from "@/data/properties";
-import type { Property } from "@/types/property";
-import PropertyCard from "@/components/PropertyCard";
+import { FormEvent, useMemo, useState } from "react";
 
-const LeafletMap = dynamic(() => import("@/components/LeafletMap"), { ssr: false });
+type ApiResult = {
+  ok: boolean;
+  status: number;
+  message: string;
+  details?: unknown;
+};
 
-export default function Home() {
-  const [query, setQuery] = useState("");
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [mobileView, setMobileView] = useState<"list" | "map">("list");
-  const itemRefs = useRef<Record<string, HTMLDivElement | null>>({});
+type FieldError = {
+  field: "apiKey" | "phoneNumber" | "message";
+  message: string;
+};
 
-  const properties: Property[] = useMemo(() => {
-    if (!query.trim()) return seedProperties;
-    const q = query.toLowerCase();
-    return seedProperties.filter(
-      (p) =>
-        p.title.toLowerCase().includes(q) ||
-        p.address.toLowerCase().includes(q)
-    );
-  }, [query]);
+function formatDetails(details: unknown) {
+  if (details === null || details === undefined) return "";
+  if (typeof details === "string") return details;
+  return JSON.stringify(details, null, 2);
+}
 
-  useEffect(() => {
-    if (!selectedId) return;
-    const el = itemRefs.current[selectedId];
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
+export default function InteraktToolPage() {
+  const [apiKey, setApiKey] = useState("");
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const [verifyResult, setVerifyResult] = useState<ApiResult | null>(null);
+  const [countryCode, setCountryCode] = useState("+91");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [message, setMessage] = useState("Hi! This message was sent from the Interakt tester.");
+  const [sendLoading, setSendLoading] = useState(false);
+  const [sendResult, setSendResult] = useState<ApiResult | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldError[]>([]);
+
+  const verifyDisabled = verifyLoading || !apiKey.trim();
+  const sendDisabled =
+    sendLoading || !apiKey.trim() || !phoneNumber.trim() || !message.trim();
+
+  const fieldErrorMap = useMemo(() => {
+    return fieldErrors.reduce<Record<string, string>>((acc, item) => {
+      acc[item.field] = item.message;
+      return acc;
+    }, {});
+  }, [fieldErrors]);
+
+  const handleVerify = async () => {
+    const sanitizedKey = apiKey.trim();
+    setFieldErrors((current) => {
+      const others = current.filter((item) => item.field !== "apiKey");
+      if (!sanitizedKey) {
+        return [...others, { field: "apiKey", message: "API key is required." }];
+      }
+      return others;
+    });
+
+    if (!sanitizedKey) {
+      setVerifyResult({
+        ok: false,
+        status: 0,
+        message: "Please provide your Interakt API key before testing.",
+      });
+      return;
     }
-  }, [selectedId]);
+
+    setVerifyLoading(true);
+    setVerifyResult(null);
+
+    try {
+      const response = await fetch("/api/interakt/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey: sanitizedKey }),
+      });
+
+      let payload: ApiResult | null = null;
+      try {
+        payload = (await response.json()) as ApiResult;
+      } catch {
+        payload = null;
+      }
+
+      setVerifyResult(
+        payload ?? {
+          ok: response.ok,
+          status: response.status,
+          message: response.ok
+            ? "Verification request completed."
+            : "Verification request failed.",
+        }
+      );
+    } catch (error) {
+      setVerifyResult({
+        ok: false,
+        status: 0,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unexpected error while verifying the API key.",
+      });
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+  const handleSend = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const errors: FieldError[] = [];
+    if (!apiKey.trim()) {
+      errors.push({ field: "apiKey", message: "API key is required." });
+    }
+    if (!phoneNumber.trim()) {
+      errors.push({
+        field: "phoneNumber",
+        message: "Enter the WhatsApp number you want to message.",
+      });
+    }
+    if (!message.trim()) {
+      errors.push({
+        field: "message",
+        message: "Message content cannot be empty.",
+      });
+    }
+
+    setFieldErrors(errors);
+    if (errors.length > 0) {
+      setSendResult({
+        ok: false,
+        status: 0,
+        message: "Fix the highlighted fields before sending.",
+      });
+      return;
+    }
+
+    setSendLoading(true);
+    setSendResult(null);
+
+    try {
+      const response = await fetch("/api/interakt/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          countryCode: countryCode.trim() || "+91",
+          phoneNumber: phoneNumber.trim(),
+          message: message.trim(),
+        }),
+      });
+
+      let payload: ApiResult | null = null;
+      try {
+        payload = (await response.json()) as ApiResult;
+      } catch {
+        payload = null;
+      }
+
+      setSendResult(
+        payload ?? {
+          ok: response.ok,
+          status: response.status,
+          message: response.ok
+            ? "Message request submitted to Interakt."
+            : "Message request failed.",
+        }
+      );
+    } catch (error) {
+      setSendResult({
+        ok: false,
+        status: 0,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unexpected error while sending the message.",
+      });
+    } finally {
+      setSendLoading(false);
+    }
+  };
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
-      <header className="sticky top-0 z-10 backdrop-blur bg-white/70 dark:bg-zinc-900/70 border-b border-black/5 dark:border-white/10">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div className="h-9 w-9 rounded-lg bg-blue-600 text-white grid place-items-center font-bold">RE</div>
-            <h1 className="text-xl font-semibold tracking-tight">Find your next home</h1>
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <main className="mx-auto flex max-w-4xl flex-col gap-10 px-4 py-12 sm:px-8">
+        <header className="space-y-4">
+          <div className="inline-flex items-center gap-2 rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-blue-200">
+            <span>Interakt Toolkit</span>
           </div>
-          <div className="hidden md:flex items-center gap-2 text-sm text-zinc-500">
-            <span>Map</span>
-            <span className="text-zinc-300">|</span>
-            <span>List</span>
-          </div>
-        </div>
-      </header>
+          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+            Interakt API Key Tester
+          </h1>
+          <p className="max-w-2xl text-base leading-relaxed text-slate-300">
+            Paste your Interakt REST API key, validate that it works, and send a
+            plain WhatsApp message without a template. Nothing is stored on the
+            server; requests are proxied directly to Interakt.
+          </p>
+        </header>
 
-      <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
-        {/* Search + actions */}
-        <div className="mb-4 flex items-center gap-3">
-          <div className="flex-1">
-            <input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search by neighborhood, address, or listing title"
-              className="w-full rounded-xl border border-black/10 dark:border-white/15 bg-white dark:bg-zinc-900 px-4 py-3 outline-none focus:ring-2 ring-blue-500"
-            />
-          </div>
-          <div className="md:hidden">
-            <div className="inline-flex rounded-lg overflow-hidden border border-black/10 dark:border-white/15">
-              <button
-                className={`px-3 py-2 text-sm ${mobileView === "list" ? "bg-blue-600 text-white" : "bg-white dark:bg-zinc-900"}`}
-                onClick={() => setMobileView("list")}
-              >
-                List
-              </button>
-              <button
-                className={`px-3 py-2 text-sm ${mobileView === "map" ? "bg-blue-600 text-white" : "bg-white dark:bg-zinc-900"}`}
-                onClick={() => setMobileView("map")}
-              >
-                Map
-              </button>
+        <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-blue-500/5 backdrop-blur sm:p-8">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold">1. Check your API key</h2>
+              <p className="mt-1 text-sm text-slate-300">
+                We call Interakt&apos;s template listing endpoint and report back
+                whatever the API returns. HTTP 401 means the key is invalid.
+              </p>
             </div>
+            <button
+              type="button"
+              onClick={handleVerify}
+              disabled={verifyDisabled}
+              className="inline-flex h-10 items-center justify-center rounded-full bg-blue-500 px-4 text-sm font-semibold text-white transition hover:bg-blue-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300 disabled:cursor-not-allowed disabled:bg-white/10"
+            >
+              {verifyLoading ? "Testing..." : "Test key"}
+            </button>
           </div>
-        </div>
 
-        {/* Content */}
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 min-h-[70vh]">
-          {/* List */}
-          <section className={`xl:block ${mobileView === "list" ? "block" : "hidden"}`}>
-            <div className="grid gap-3">
-              {properties.map((p) => (
-                <div key={p.id} ref={(el) => { itemRefs.current[p.id] = el; }}>
-                  <PropertyCard
-                    property={p}
-                    selected={p.id === selectedId}
-                    onClick={() => {
-                      setSelectedId(p.id);
-                      setMobileView("map");
-                    }}
-                  />
-                </div>
-              ))}
-              {properties.length === 0 && (
-                <div className="text-sm text-zinc-500">No results</div>
+          <div className="mt-6 space-y-4">
+            <label className="block text-sm font-medium text-slate-200">
+              Interakt API key
+            </label>
+            <input
+              type="password"
+              autoComplete="off"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              className={`w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm shadow-inner shadow-black/40 transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/40 ${
+                fieldErrorMap.apiKey ? "border-rose-400" : ""
+              }`}
+              placeholder="Paste the API key from your Interakt dashboard"
+            />
+            {fieldErrorMap.apiKey && (
+              <p className="text-sm text-rose-300">{fieldErrorMap.apiKey}</p>
+            )}
+          </div>
+
+          {verifyResult && (
+            <div
+              className={`mt-6 rounded-2xl border px-5 py-4 text-sm ${
+                verifyResult.ok
+                  ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-200"
+                  : "border-rose-400/40 bg-rose-400/10 text-rose-100"
+              }`}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2 text-xs uppercase tracking-[0.2em]">
+                <span>{verifyResult.ok ? "Success" : "Error"}</span>
+                <span>Status {verifyResult.status}</span>
+              </div>
+              <p className="mt-3 text-base font-semibold">
+                {verifyResult.message}
+              </p>
+              {verifyResult.details && (
+                <details className="mt-3">
+                  <summary className="cursor-pointer text-xs font-medium text-slate-200">
+                    View response payload
+                  </summary>
+                  <pre className="mt-2 max-h-64 overflow-auto rounded-xl bg-black/40 p-4 text-xs text-slate-200">
+                    {formatDetails(verifyResult.details)}
+                  </pre>
+                </details>
               )}
             </div>
-          </section>
+          )}
+        </section>
 
-          {/* Map */}
-          <section className={`xl:block ${mobileView === "map" ? "block" : "hidden"}`}>
-            <div className="h-[70vh] xl:h-[80vh] sticky top-[92px]">
-              <LeafletMap
-                properties={properties}
-                selectedId={selectedId}
-                onMarkerClick={(id) => {
-                  setSelectedId(id);
-                }}
-              />
+        <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-purple-500/5 backdrop-blur sm:p-8">
+          <h2 className="text-xl font-semibold">2. Send a plain message</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Interakt needs the receiver&apos;s WhatsApp number, a country code, and
+            the message text. The call will fail if the number hasn&apos;t opted in
+            to receive messages from your business.
+          </p>
+
+          <form className="mt-6 space-y-5" onSubmit={handleSend}>
+            <div className="grid gap-4 sm:grid-cols-[120px_1fr]">
+              <div>
+                <label className="block text-sm font-medium text-slate-200">
+                  Country code
+                </label>
+                <input
+                  value={countryCode}
+                  onChange={(event) => setCountryCode(event.target.value)}
+                  className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 px-3 py-3 text-sm focus:border-purple-400 focus:outline-none focus:ring-2 focus:ring-purple-400/40"
+                  placeholder="+91"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-200">
+                  WhatsApp number
+                </label>
+                <input
+                  value={phoneNumber}
+                  onChange={(event) => setPhoneNumber(event.target.value)}
+                  className={`mt-1 w-full rounded-2xl border border-white/10 bg-black/40 px-3 py-3 text-sm focus:border-purple-400 focus:outline-none focus:ring-2 focus:ring-purple-400/40 ${
+                    fieldErrorMap.phoneNumber ? "border-rose-400" : ""
+                  }`}
+                  placeholder="9876543210"
+                />
+                {fieldErrorMap.phoneNumber && (
+                  <p className="mt-1 text-sm text-rose-300">
+                    {fieldErrorMap.phoneNumber}
+                  </p>
+                )}
+              </div>
             </div>
-          </section>
-        </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-200">
+                Message text
+              </label>
+              <textarea
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                rows={4}
+                className={`mt-1 w-full rounded-2xl border border-white/10 bg-black/40 px-3 py-3 text-sm focus:border-purple-400 focus:outline-none focus:ring-2 focus:ring-purple-400/40 ${
+                  fieldErrorMap.message ? "border-rose-400" : ""
+                }`}
+                placeholder="Enter the WhatsApp message you want to send"
+              />
+              {fieldErrorMap.message && (
+                <p className="mt-1 text-sm text-rose-300">
+                  {fieldErrorMap.message}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={sendDisabled}
+                className="inline-flex h-11 items-center justify-center rounded-full bg-purple-500 px-6 text-sm font-semibold text-white transition hover:bg-purple-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300 disabled:cursor-not-allowed disabled:bg-white/10"
+              >
+                {sendLoading ? "Sending..." : "Send message"}
+              </button>
+              <p className="text-xs text-slate-400">
+                Regular (non-template) messages are allowed only during the 24
+                hour session window.
+              </p>
+            </div>
+          </form>
+
+          {sendResult && (
+            <div
+              className={`mt-6 rounded-2xl border px-5 py-4 text-sm ${
+                sendResult.ok
+                  ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-200"
+                  : "border-rose-400/40 bg-rose-400/10 text-rose-100"
+              }`}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2 text-xs uppercase tracking-[0.2em]">
+                <span>{sendResult.ok ? "Success" : "Error"}</span>
+                <span>Status {sendResult.status}</span>
+              </div>
+              <p className="mt-3 text-base font-semibold">
+                {sendResult.message}
+              </p>
+              {sendResult.details && (
+                <details className="mt-3">
+                  <summary className="cursor-pointer text-xs font-medium text-slate-200">
+                    View response payload
+                  </summary>
+                  <pre className="mt-2 max-h-64 overflow-auto rounded-xl bg-black/40 p-4 text-xs text-slate-200">
+                    {formatDetails(sendResult.details)}
+                  </pre>
+                </details>
+              )}
+            </div>
+          )}
+        </section>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the home page with an Interakt API tester that validates keys and sends plain WhatsApp messages
- add server-side routes that proxy Interakt template lookups and plain message requests while returning raw payloads
- refresh the site metadata and README to describe the new toolkit and how to use it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9839ecd24832baf64ef7f7cabe115